### PR TITLE
fix: update Docker image to use Go 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal image size
-FROM golang:1.21-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make


### PR DESCRIPTION
## Summary
Updates the Docker base image from Go 1.21 to Go 1.22 to align with the project's go.mod requirements.

## Changes
- Changed Dockerfile FROM golang:1.21-alpine to golang:1.22-alpine

## Why This Is Needed
- go.mod requires Go 1.22.0 minimum
- Using Go 1.21 in Docker could cause compatibility issues
- Ensures consistent Go version across all build environments

This fix will resolve the Docker build failures in CI/CD.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>